### PR TITLE
Use GitHub Packages registry instead of non-working cluster one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DB_SCRIPTS_IMAGE_NAME = 10.40.71.55:5000/rsww_184529_db_scripts
+DB_SCRIPTS_IMAGE_NAME = ghcr.io/yetanotherspieskowcy/rsww_184529_db_scripts
 
 # [ran on a dev machine]
 # Builds and runs the whole dev stack, making sure to fill the DB

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ make dev-run
 
 ### How to deploy to production?
 
-When running on production, you should first upload the images to registry (done on dev machine):
+In order to do that, you'll first need to make sure that [you have configured authentication for GitHub Packages registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+Once you do, you can build and push the images to the registry with following targets (done on dev machine):
 ```console
 make build
 make push

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -11,13 +11,13 @@ services:
         - path: ./api_gateway
           action: rebuild
   db-sql:
-    image: 10.40.71.55:5000/rsww_184529_db_sql
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_db_sql
     ports:
       - "15432:5432"
     build:
       context: ./db_sql
   db-mongo:
-    image: 10.40.71.55:5000/rsww_184529_db_mongo
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_db_mongo
     ports:
       - "17017:27017"
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,11 +18,11 @@ services:
     env_file:
       - ./default.env
   tour-operator:
-    image: 10.40.71.55:5000/rsww_184529_tour_operator
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_tour_operator
     build:
         context: ./tour_operator
   price-calculator:
-    image: 10.40.71.55:5000/rsww_184529_price_calculator
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_price_calculator
     build:
       context: ./price_calculator
     depends_on:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   proxy:
-    image: 10.40.71.55:5000/rsww_184529_proxy
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_proxy
     ports:
       - "8080:80"
     build: 
@@ -8,11 +8,11 @@ services:
       additional_contexts:
         - static=./static
   broker:
-    image: 10.40.71.55:5000/rsww_184529_broker
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_broker
     build:
       context: ./broker
   api-gateway:
-    image: 10.40.71.55:5000/rsww_184529_api_gateway
+    image: ghcr.io/yetanotherspieskowcy/rsww_184529_api_gateway
     build:
       context: ./api_gateway
     env_file:


### PR DESCRIPTION
It turns out that the registry on the cluster is actually dead and it seems that every image on the cluster has been pulled from a different registry - for example, a publicly hosted GitLab one.

Either way, the cluster manual allows us to publish the image to an outside registry which should be easier to manage than having to push to a registry that's placed behind a VPN *and* a bastion:
![image](https://github.com/YetAnotherSpieskowcy/travel-agency-app/assets/6032823/b751955f-e859-4413-8f2f-1835a1ae292d)
