### PR TITLE
Improve service communication and HTTP request rigidity

### DIFF
--- a/api_gateway/src/main/kotlin/pl/edu/pg/rsww/apigateway/RoutingController.kt
+++ b/api_gateway/src/main/kotlin/pl/edu/pg/rsww/apigateway/RoutingController.kt
@@ -72,6 +72,7 @@ public class RoutingController(
         if (serviceName != "auth") {
             if (!(headers["cookie"]?.contains("user") ?: false)) {
                 var builder = ResponseEntity.status(300)
+                builder.header("Cache-Control", "no-cache")
                 builder.header("HX-Redirect", "/login.html")
                 return builder.body("")
             }
@@ -93,9 +94,17 @@ public class RoutingController(
         val exchangeName = "$serviceName.requests"
         val rawResponse =
             template.convertSendAndReceive(exchangeName, exchangeName, rawMsg as Any) as String
+        if (rawResponse == null) {
+            // the request timed out waiting for the response message in the queue
+            return ResponseEntity
+                .status(504)
+                .header("Cache-Control", "no-cache")
+                .body("")
+        }
         val resp = Json.decodeFromString<ResponseMessage>(rawResponse)
 
         var builder = ResponseEntity.status(resp.status)
+        builder.header("Cache-Control", "no-cache")
         resp.headers.forEach { key, value -> builder = builder.header(key, value) }
         return builder.body(resp.body)
     }

--- a/api_gateway/src/main/resources/application.properties
+++ b/api_gateway/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
 spring.rabbitmq.publisher-confirm-type=correlated
 spring.rabbitmq.publisher-returns=true
+spring.rabbitmq.template.reply-timeout=30000

--- a/auth/src/main/resources/application.properties
+++ b/auth/src/main/resources/application.properties
@@ -5,5 +5,6 @@ spring.rabbitmq.host=broker
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
+spring.rabbitmq.listener.default-requeue-rejected=false
 spring.rabbitmq.publisher-confirm-type=correlated
 spring.rabbitmq.publisher-returns=true

--- a/price_calculator/src/main/resources/application.properties
+++ b/price_calculator/src/main/resources/application.properties
@@ -5,5 +5,6 @@ spring.rabbitmq.host=broker
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
+spring.rabbitmq.listener.default-requeue-rejected=false
 spring.rabbitmq.publisher-confirm-type=correlated
 spring.rabbitmq.publisher-returns=true

--- a/tour_operator/src/main/resources/application.properties
+++ b/tour_operator/src/main/resources/application.properties
@@ -5,5 +5,6 @@ spring.rabbitmq.host=broker
 spring.rabbitmq.port=5672
 spring.rabbitmq.username=guest
 spring.rabbitmq.password=guest
+spring.rabbitmq.listener.default-requeue-rejected=false
 spring.rabbitmq.publisher-confirm-type=correlated
 spring.rabbitmq.publisher-returns=true


### PR DESCRIPTION
A few small improvements to service communication and HTTP requests:
- added `Cache-Control: no-cache` header to prevent caching issues
- increased HTTP request timeout to 30 seconds (value has no special meaning, it just seemed like a reasonable limit compared to 5 seconds; though 15 seconds could also be fine)
- fixed NullPointerException on timeout - we now return 504 when that happens
- disabled automatic requeueing of messages when a listener throws an unexpected exception
    - without this, the performance of a service were significantly degraded as soon as a rabbit listener threw an exception as it was looping indefinitely (default behavior documented in (Exception Handling section at spring-amqp docs](https://docs.spring.io/spring-amqp/reference/amqp/exception-handling.html))
    - [we could requeue until N tries](https://www.baeldung.com/spring-amqp-error-handling#4-processing-dead-letter-queue-messages) but I don't think it's worth losing our time on - it's unlikely that a retry is going to help and a single failed request is less likely to be noticed than the degraded performance of the whole service
