### PR TITLE
Fix nginx charset

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -3,6 +3,7 @@ events {
 }
 http {
   include /etc/nginx/mime.types;
+  charset utf-8;
 
   upstream api-gateway {
     server api-gateway:8080;


### PR DESCRIPTION
I was getting weird chars instead of Polish chars for files served by nginx (i.e. html files). This fixes that. May have been caused by the addition of mime types include.